### PR TITLE
Fixing the new music disc "relic" not being supported by the rounddiscs option

### DIFF
--- a/common/src/main/resources/resourcepacks/coloredwaterbucket/pack.mcmeta
+++ b/common/src/main/resources/resourcepacks/coloredwaterbucket/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 9,
+    "pack_format": 15,
     "description": "§2Makes the water bucket respect biome colors"
   }
 }

--- a/common/src/main/resources/resourcepacks/fancyfurnace/pack.mcmeta
+++ b/common/src/main/resources/resourcepacks/fancyfurnace/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 9,
+    "pack_format": 15,
     "description": "§2Changes the model of the furnace to be 3D"
   }
 }

--- a/common/src/main/resources/resourcepacks/nobrewingbottles/pack.mcmeta
+++ b/common/src/main/resources/resourcepacks/nobrewingbottles/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 9,
+    "pack_format": 15,
     "description": "§2Removes the bottles from the brewing stand"
   }
 }

--- a/common/src/main/resources/resourcepacks/rounddiscs/assets/minecraft/models/item/music_disc_relic.json
+++ b/common/src/main/resources/resourcepacks/rounddiscs/assets/minecraft/models/item/music_disc_relic.json
@@ -1,0 +1,15 @@
+{
+	"parent": "minecraft:item/generated",
+	"textures": {
+		"layer0": "minecraft:item/music_disc_relic"
+	},
+	
+	"overrides": [
+        {
+            "predicate": {
+                "round": 1
+            },
+            "model": "minecraft:item/music_disc_relic_round"
+        }
+    ]
+}

--- a/common/src/main/resources/resourcepacks/rounddiscs/assets/minecraft/models/item/music_disc_relic_round.json
+++ b/common/src/main/resources/resourcepacks/rounddiscs/assets/minecraft/models/item/music_disc_relic_round.json
@@ -1,0 +1,6 @@
+{
+	"parent": "visualoverhaul:item/round_disc",
+	"textures": {
+		"0": "minecraft:item/music_disc_relic"
+	}
+}

--- a/common/src/main/resources/resourcepacks/rounddiscs/pack.mcmeta
+++ b/common/src/main/resources/resourcepacks/rounddiscs/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 9,
+    "pack_format": 15,
     "description": "§2Makes the spinning discs on Jukeboxes round"
   }
 }


### PR DESCRIPTION
I added relic model to the rounddiscs ressources pack
I also updated the ressources packs mcmeta to 1.20